### PR TITLE
ci: add version bump workflow

### DIFF
--- a/,github/workflows/version-bump.yml
+++ b/,github/workflows/version-bump.yml
@@ -1,0 +1,36 @@
+name: Version Bump
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Select version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Universal Version Bump
+        uses: taj54/universal-version-bump@v0.14.0
+        with:
+          release_type: ${{ inputs.release_type }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Added workflow for version bumping.
- Uses `taj54/universal-version-bump`.
- Allows patch, minor, and major releases.
- Uses workflow_dispatch for manual trigger.
- Configured GITHUB_TOKEN access.

close #1 